### PR TITLE
Add Output variables

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-variable "iam_user_name" {
+output "aws_iam_user_name" {
   description = "The name of the IAM User created."
   value       = "${aws_iam_user.rubrik.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+variable "iam_user_name" {
+  description = "The name of the IAM User created."
+  value       = "${aws_iam_user.rubrik.name}"
+}


### PR DESCRIPTION
# Description

Adds the AWS IAM User name as an output variable

## Motivation and Context

Terraform modules do not support the "depends_on" syntax so we need to pass in a variable from the CloudOut --> CloudOn module to dynamically build that relationship. 




