### PR TITLE
Added support for Terraform 0.15 and missing ACL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 terraform.tfstate*
 .terraform*
+iam_keys.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 terraform.tfstate*
 .terraform*
 iam_keys.txt
+settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-terraform.tfstate
-.terraform/plugins/*
+terraform.tfstate*
+.terraform
+.terraform.lock.hcl
+theplan

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 terraform.tfstate*
-.terraform
-.terraform.lock.hcl
-theplan
+.terraform*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terraform module that configures an AWS S3 archive target and adds that target t
 - Create a new user specific to Rubrik
 - Create a new IAM Policy with the correct permissions and attached to the new user.
 - Create a new KMS Key to use for encryption
-- Adds the S3 Bucket to the Rubrik cluster as an archival location
+- (optionally) Adds the S3 Bucket to the Rubrik cluster as an archival location
 
 ## Documentation
 
@@ -16,6 +16,7 @@ Here are some resources to get you started! If you find any challenges from this
 
 - [Quick Start Guide](/docs/quick-start.md)
 - [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
+  - Only required to run the sample workflow for adding the archival location to Rubrik
 
 ## Authentication
 
@@ -79,6 +80,7 @@ There are a few services you'll need in order to get this project off the ground
 
 - [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
 - [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+  - Only required to run the sample workflow for adding the archival location to Rubrik
 
 ## How You Can Help
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 
 Terraform module that configures an AWS S3 archive target and adds that target to the Rubrik cluster. The following steps are completed by the module:
 
-* Create a new AWS S3 Bucket
-* Create a new user specific to Rubrik
-* Create a new IAM Policy with the correct permissions and attached to the new user.
-* Create a new KMS Key to use for encryption
-* Adds the S3 Bucket to the Rubrik cluster as an archival location
+- Create a new AWS S3 Bucket
+- Create a new user specific to Rubrik
+- Create a new IAM Policy with the correct permissions and attached to the new user.
+- Create a new KMS Key to use for encryption
+- Adds the S3 Bucket to the Rubrik cluster as an archival location
 
 ## Documentation
 
 Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issueand let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
 
-* [Quick Start Guide](/docs/quick-start.md)
-* [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
+- [Quick Start Guide](/docs/quick-start.md)
+- [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
 
 ### Usage
 
@@ -32,51 +32,49 @@ module "rubrik_aws_cloudout" {
 
 The following are the variables accepted by the module.
 
-| Name                 | Description                                                                                                               |  Type  |      Default     | Required |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------|:------:|:----------------:|:--------:|
-| bucket_name          | The name of the S3 bucket to use as an archive target.                                                                    | string |                  |    yes   |
-| archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                                | string |                  |    yes   |
-| bucket_force_destory | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |       false      |    no    |
+| Name                 | Description                                                                                                               |  Type  |     Default      | Required |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- | :----: | :--------------: | :------: |
+| bucket_name          | The name of the S3 bucket to use as an archive target.                                                                    | string |                  |   yes    |
+| archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                                | string |                  |   yes    |
+| bucket_force_destory | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
 | storage_class        | The storage class of the S3 Bucket. Valid choices are standard, standard_ia, and reduced_redundancy.                      | string |     standard     |    no    |
 | iam_user_name        | The name of the IAM User to create.                                                                                       | string |      rubrik      |    no    |
 | iam_policy_name      | The name of the IAM Policy configured with the correct CloudOut permissions.                                              | string | rubrik-cloud-out |    no    |
 | kms_key_alias        | The alias for the KMS Key ID.                                                                                             | string | rubrik-cloud-out |    no    |
-| timeout              | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.              |   int  |        120       |    no    |
+| timeout              | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.              |  int   |       120        |    no    |
 
-| WARNING: The new IAM User Secret key is stored in plaintext in the `terraform.tfstate` file. Please ensure this file is stored properly.  |
-| --- |
+| WARNING: The new IAM User Secret key is stored in plaintext in the `terraform.tfstate` file. Please ensure this file is stored properly. |
+| ---------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## Outputs
 
 The following are the variables outputed by the module.
 
 | Name                | Description                                                     |
-|---------------------|-----------------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------- |
 | aws_iam_user_name   | The name of the AWS IAM User created.                           |
 | rubrik_archive_name | he name of the archival location created on the Rubrik cluster. |
-
-
 
 ## Prerequisites
 
 There are a few services you'll need in order to get this project off the ground:
 
-* [Terraform](https://www.terraform.io/downloads.html) v0.10.3 or greater
-* [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+- [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
+- [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
 
 ## How You Can Help
 
 We glady welcome contributions from the community. From updating the documentation to adding more functions for Python, all ideas are welcome. Thank you in advance for all of your issues, pull requests, and comments! :star:
 
-* [Contributing Guide](CONTRIBUTING.md)
-* [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## License
 
-* [MIT License](LICENSE)
+- [MIT License](LICENSE)
 
 ## About Rubrik Build
 
 We encourage all contributors to become members. We aim to grow an active, healthy community of contributors, reviewers, and code owners. Learn more in our [Welcome to the Rubrik Build Community](https://github.com/rubrikinc/welcome-to-rubrik-build) page.
 
-We'd  love to hear from you! Email us: build@rubrik.com 
+We'd love to hear from you! Email us: build@rubrik.com

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ The following are the variables printed by the module.
 | aws_iam_user_name  | The name of the AWS IAM User created.                |
 | aws_iam_access_key | The Access Key of the AWS IAM User that was created. |
 | aws_iam_secret_key | The Secret Key of the AWS IAM User that was created. |
-| aws_iam_policy     | The name ofthe AWS Policy created for the IAM User.  |
+| aws_iam_policy     | The name of the AWS Policy created for the IAM User. |
 | aws_bucket         | The AWS S3 bucket that was created.                  |
 | aws_kms_key        | The KMS Key ID of the KMS key that was created.      |
-| aws_region         | The AWS region where the resoruces were created.     |
+| aws_region         | The AWS region where the resources were created.     |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,15 @@ The following are the variables accepted by the module.
 
 The following are the variables printed by the module.
 
-| Name                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| aws_iam_user_name   | The name of the AWS IAM User created.                           |
-| rubrik_archive_name | he name of the archival location created on the Rubrik cluster. |
+| Name               | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| aws_iam_user_name  | The name of the AWS IAM User created.                |
+| aws_iam_access_key | The Access Key of the AWS IAM User that was created. |
+| aws_iam_secret_key | The Secret Key of the AWS IAM User that was created. |
+| aws_iam_policy     | The name ofthe AWS Policy created for the IAM User.  |
+| aws_bucket         | The AWS S3 bucket that was created.                  |
+| aws_kms_key        | The KMS Key ID of the KMS key that was created.      |
+| aws_region         | The AWS region where the resoruces were created.     |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terraform module that configures an AWS S3 archive target and adds that target t
 
 ## Documentation
 
-Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issueand let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
+Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issue and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
 
 - [Quick Start Guide](/docs/quick-start.md)
 - [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
@@ -50,7 +50,7 @@ The following are the variables accepted by the module.
 | aws_region           | Region to create S3 bucket in                                                                                         | string |                  |   yes    |
 | bucket_name          | The name of the S3 bucket to use as an archive target.                                                                | string |                  |   yes    |
 | archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                            | string |                  |   yes    |
-| bucket_force_destory | When true, indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
+| bucket_force_destroy | When true, indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
 | save_keys            | When true, save a copy of created IAM Access and Secret keys in iam_keys.txt.                                         |  bool  |      false       |    no    |
 | storage_class        | The storage class of the S3 Bucket. Valid choices are standard, standard_ia, and reduced_redundancy.                  | string |     standard     |    no    |
 | iam_user_name        | The name of the IAM User to create.                                                                                   | string |      rubrik      |    no    |
@@ -66,7 +66,7 @@ The following are the variables accepted by the module.
 
 ## Outputs
 
-The following are the variables outputed by the module.
+The following are the variables printed by the module.
 
 | Name                | Description                                                     |
 | ------------------- | --------------------------------------------------------------- |

--- a/add_archive_to_cluster.tf.example
+++ b/add_archive_to_cluster.tf.example
@@ -1,0 +1,22 @@
+############################################
+#     Add Archive to Rubrik cluster        #
+############################################
+
+# This example requires the Rubrik Terraform module.
+# Currently the Rubrik Terraform Module only supports Terraform up to v0.11
+
+resource "rubrik_aws_s3_cloudout" "archive-target" {
+    aws_access_key    = "${aws_iam_access_key.rubrik-user.id}"
+    aws_secret_key    = "${aws_iam_access_key.rubrik-user.secret}"
+    aws_bucket        = "${aws_s3_bucket.archive_target.bucket}"
+    storage_class     = "${var.storage_class}"
+    archive_name      = "${var.archive_name}"
+    aws_region        = "${data.aws_region.current.name}"
+    kms_master_key_id = "${aws_kms_key.rubrik-cloudout.key_id}"
+    timeout           = "${var.timeout}"
+}
+
+output "rubrik_archive_name" {
+    description = "The name of the archival location created on the Rubrik cluster."
+    value       = "${rubrik_aws_s3_cloudout.archive-target.archive_name}"
+}

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -117,8 +117,6 @@ rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 ```
 
-### Gain Access to the Rubrik Cloud Cluster AMI
-
 ### Planning
 
 Run `terraform plan` to get information about what will happen when we apply the configuration; this will test that everything is set up correctly.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -65,10 +65,15 @@ The following are the variables accepted by the module.
 
 The following are the variables printed by the module.
 
-| Name                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| aws_iam_user_name   | The name of the AWS IAM User created.                           |
-| rubrik_archive_name | he name of the archival location created on the Rubrik cluster. |
+| Name               | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| aws_iam_user_name  | The name of the AWS IAM User created.                |
+| aws_iam_access_key | The Access Key of the AWS IAM User that was created. |
+| aws_iam_secret_key | The Secret Key of the AWS IAM User that was created. |
+| aws_iam_policy     | The name ofthe AWS Policy created for the IAM User.  |
+| aws_bucket         | The AWS S3 bucket that was created.                  |
+| aws_kms_key        | The KMS Key ID of the KMS key that was created.      |
+| aws_region         | The AWS region where the resoruces were created.     |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,13 +2,13 @@
 
 Configure an AWS S3 archive target and add that target to the Rubrik cluster. The following steps are completed by the module:
 
-* Create a new AWS S3 Bucket
-* Create a new user specific to Rubrik
-* Create a new IAM Policy with the correct permissions and attached to the new user.
-* Create a new KMS Key to use for encryption
-* Adds the S3 Bucket to the Rubrik cluster as an archival location
+- Create a new AWS S3 Bucket
+- Create a new user specific to Rubrik
+- Create a new IAM Policy with the correct permissions and attached to the new user.
+- Create a new KMS Key to use for encryption
+- Adds the S3 Bucket to the Rubrik cluster as an archival location
 
-Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a *nix shell (bash, zsh, etc).
+Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
 ## Configuration
 
@@ -29,38 +29,37 @@ You may also add additional variables, such as `storage_class`, to overwrite the
 
 The following are the variables accepted by the module.
 
-| Name                 | Description                                                                                                               |  Type  |      Default     | Required |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------|:------:|:----------------:|:--------:|
-| bucket_name          | The name of the S3 bucket to use as an archive target.                                                                    | string |                  |    yes   |
-| archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                                | string |                  |    yes   |
-| bucket_force_destory | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |       false      |    no    |
+| Name                 | Description                                                                                                               |  Type  |     Default      | Required |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- | :----: | :--------------: | :------: |
+| bucket_name          | The name of the S3 bucket to use as an archive target.                                                                    | string |                  |   yes    |
+| archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                                | string |                  |   yes    |
+| bucket_force_destory | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
 | storage_class        | The storage class of the S3 Bucket. Valid choices are standard, standard_ia, and reduced_redundancy.                      | string |     standard     |    no    |
 | iam_user_name        | The name of the IAM User to create.                                                                                       | string |      rubrik      |    no    |
 | iam_policy_name      | The name of the IAM Policy configured with the correct CloudOut permissions.                                              | string | rubrik-cloud-out |    no    |
 | kms_key_alias        | The alias for the KMS Key ID.                                                                                             | string | rubrik-cloud-out |    no    |
-| timeout              | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.              |   int  |        120       |    no    |
+| timeout              | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.              |  int   |       120        |    no    |
 
-
-| WARNING: The new IAM User Secret key is stored in plaintext in the `terraform.tfstate` file. Please ensure this file is stored properly.  |
-| --- |
+| WARNING: The new IAM User Secret key is stored in plaintext in the `terraform.tfstate` file. Please ensure this file is stored properly. |
+| ---------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## Outputs
 
 The following are the variables outputed by the module.
 
 | Name                | Description                                                     |
-|---------------------|-----------------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------- |
 | aws_iam_user_name   | The name of the AWS IAM User created.                           |
 | rubrik_archive_name | he name of the archival location created on the Rubrik cluster. |
 
 ## Running the Terraform Configuration
 
-This section outlines what is required to run the configuration defined above. 
+This section outlines what is required to run the configuration defined above.
 
 ### Prerequisites
 
-* [Terraform](https://www.terraform.io/downloads.html) v0.10.3 or greater
-* [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+- [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
+- [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
 
 ### Initialize the Directory
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -70,10 +70,10 @@ The following are the variables printed by the module.
 | aws_iam_user_name  | The name of the AWS IAM User created.                |
 | aws_iam_access_key | The Access Key of the AWS IAM User that was created. |
 | aws_iam_secret_key | The Secret Key of the AWS IAM User that was created. |
-| aws_iam_policy     | The name ofthe AWS Policy created for the IAM User.  |
+| aws_iam_policy     | The name of the AWS Policy created for the IAM User. |
 | aws_bucket         | The AWS S3 bucket that was created.                  |
 | aws_kms_key        | The KMS Key ID of the KMS key that was created.      |
-| aws_region         | The AWS region where the resoruces were created.     |
+| aws_region         | The AWS region where the resources were created.     |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,7 +47,7 @@ The following are the variables accepted by the module.
 | aws_region           | Region to create S3 bucket in                                                                                         | string |                  |   yes    |
 | bucket_name          | The name of the S3 bucket to use as an archive target.                                                                | string |                  |   yes    |
 | archive_name         | The name of the Rubrik archive location in the Rubrik GUI.                                                            | string |                  |   yes    |
-| bucket_force_destory | When true, indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
+| bucket_force_destroy | When true, indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. |  bool  |      false       |    no    |
 | save_keys            | When true, save a copy of created IAM Access and Secret keys in iam_keys.txt.                                         |  bool  |      false       |    no    |
 | storage_class        | The storage class of the S3 Bucket. Valid choices are standard, standard_ia, and reduced_redundancy.                  | string |     standard     |    no    |
 | iam_user_name        | The name of the IAM User to create.                                                                                   | string |      rubrik      |    no    |
@@ -63,7 +63,7 @@ The following are the variables accepted by the module.
 
 ## Outputs
 
-The following are the variables outputed by the module.
+The following are the variables printed by the module.
 
 | Name                | Description                                                     |
 | ------------------- | --------------------------------------------------------------- |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,7 +6,7 @@ Configure an AWS S3 archive target and add that target to the Rubrik cluster. Th
 - Create a new user specific to Rubrik
 - Create a new IAM Policy with the correct permissions and attached to the new user
 - Create a new KMS Key to use for encryption
-- Configure a Rubrik cluster to use the new S3 Bucket as an archival location
+- (optionally) Configure a Rubrik cluster to use the new S3 Bucket as an archival location
 
 Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
@@ -78,6 +78,7 @@ This section outlines what is required to run the configuration defined above.
 
 - [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
 - [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+  - Only required to run the sample workflow for adding the archival location to Rubrik
 
 ### Initialize the Directory
 
@@ -119,7 +120,7 @@ Run `terraform plan` to get information about what will happen when we apply the
 
 ### Applying
 
-We can now apply the configuration to create the necessary resources in AWS. After AWS is configured, a new Archive Location will be added to your Rubrik cluster.
+We can now apply the configuration to create the necessary resources in AWS. After AWS is configured, (optionally) a new Archive Location will be added to your Rubrik cluster.
 
 ### Destroying
 

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,8 @@ resource "aws_iam_policy" "cloud-out-permissions" {
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket",
-                "s3:GetBucketLocation"
+                "s3:GetBucketLocation",
+                "s3:GetBucketAcl"
             ],
             "Resource": "arn:aws:s3:::${var.bucket_name}"
         },

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.10.3" # introduction of Local Values configuration language feature
+  required_version = ">= 0.15.4"
 }
 
 #############################
@@ -22,11 +22,11 @@ provider "aws" {
 ###############################
 
 resource "aws_iam_user" "rubrik" {
-  name = "${var.iam_user_name}"
+  name = var.iam_user_name
 }
 
 resource "aws_iam_policy" "cloud-out-permissions" {
-  name = "${var.iam_policy_name}"
+  name = var.iam_policy_name
 
   policy = <<EOF
 {
@@ -67,20 +67,20 @@ EOF
 }
 
 resource "aws_iam_user_policy_attachment" "rubrik-user" {
-  user       = "${aws_iam_user.rubrik.name}"
-  policy_arn = "${aws_iam_policy.cloud-out-permissions.arn}"
+  user       = aws_iam_user.rubrik.name
+  policy_arn = aws_iam_policy.cloud-out-permissions.arn
 }
 
 resource "aws_iam_access_key" "rubrik-user" {
-  user = "${aws_iam_user.rubrik.name}"
+  user = aws_iam_user.rubrik.name
 }
 
 ###############################
 #      Create S3 Bucket       #
 ###############################
 resource "aws_s3_bucket" "archive_target" {
-  bucket        = "${var.bucket_name}"
-  force_destroy = "${var.bucket_force_destory}"
+  bucket        = var.bucket_name
+  force_destroy = var.bucket_force_destory
 }
 
 ############################################
@@ -90,70 +90,55 @@ resource "aws_kms_key" "rubrik-cloudout" {
   description = "KMS Key for Rubrik CloudOut."
 
   policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Id": "key-consolepolicy-3",
-    "Statement": [
-        {
-            "Sid": "Enable IAM User Permissions",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-            },
-            "Action": "kms:*",
-            "Resource": "*"
-        },
-        {
-            "Sid": "Allow access for Key Administrators",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "${aws_iam_user.rubrik.arn}"
-            },
-            "Action": [
-                "kms:Encrypt",
-                "kms:Decrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-                "kms:DescribeKey"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "Allow use of the key",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "${aws_iam_user.rubrik.arn}"
-            },
-            "Action": [
-                "kms:Encrypt",
-                "kms:Decrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-                "kms:DescribeKey"
-            ],
-            "Resource": "*"
-        }
-    ]
+{
+  "Version": "2012-10-17",
+  "Id": "Rubrik-CloudOut-KMS-Key",
+  "Statement": [
+      {
+          "Sid": "Enable IAM User Permissions",
+          "Effect": "Allow",
+          "Principal": {
+              "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          },
+          "Action": "kms:*",
+          "Resource": "*"
+      },
+      {
+          "Sid": "Allow access for Key Administrators",
+          "Effect": "Allow",
+          "Principal": {
+              "AWS":"${aws_iam_user.rubrik.arn}"
+          },
+          "Action": [
+              "kms:Encrypt",
+              "kms:Decrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*",
+              "kms:DescribeKey"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "Allow use of the key",
+          "Effect": "Allow",
+          "Principal": {
+              "AWS": "${aws_iam_user.rubrik.arn}"
+          },
+          "Action": [
+              "kms:Encrypt",
+              "kms:Decrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*",
+              "kms:DescribeKey"
+          ],
+          "Resource": "*"
+      }
+  ]
 }
   EOF
 }
 
-resource "aws_kms_alias" "a" {
-  name          = "alias/${var.kms_key_alias}"
-  target_key_id = "${aws_kms_key.rubrik-cloudout.key_id}"
-}
-
-############################################
-#     Add Archive to Rubrik cluster        #
-############################################
-
-resource "rubrik_aws_s3_cloudout" "archive-target" {
-  aws_access_key    = "${aws_iam_access_key.rubrik-user.id}"
-  aws_secret_key    = "${aws_iam_access_key.rubrik-user.secret}"
-  aws_bucket        = "${aws_s3_bucket.archive_target.bucket}"
-  storage_class     = "${var.storage_class}"
-  archive_name      = "${var.archive_name}"
-  aws_region        = "${data.aws_region.current.name}"
-  kms_master_key_id = "${aws_kms_key.rubrik-cloudout.key_id}"
-  timeout           = "${var.timeout}"
+resource "aws_kms_alias" "rubrik-cloudout" {
+  name          = join ("/", ["alias", var.kms_key_alias])
+  target_key_id = aws_kms_key.rubrik-cloudout.key_id
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "aws_region" "current" {}
 ##########################
 
 provider "aws" {
-  region = var.region
+  region = var.aws_region
 }
 
 ###############################

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,14 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+##########################
+# Configure the provider #
+##########################
+
+provider "aws" {
+  region = var.region
+}
+
 ###############################
 # AWS IAM User and Permission #
 ###############################

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  required_version = ">= 0.15.4"
-}
-
 #############################
 # Dynamic Variable Creation #
 #############################

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,31 @@
-output "aws_iam_user_name" {
-  description = "The name of the AWS IAM User created."
-  value       = "${aws_iam_user.rubrik.name}"
+data "template_file" "iam_secret_key" {
+  template = aws_iam_access_key.rubrik-user.secret
 }
 
-output "rubrik_archive_name" {
-  description = "The name of the archival location created on the Rubrik cluster."
-  value       = "${rubrik_aws_s3_cloudout.archive-target.archive_name}"
+output "aws_iam_user_info" {
+  description = "The information about the AWS IAM User created."
+  value       = {
+    "name"               = aws_iam_user.rubrik.name
+    "aws_iam_access_key" = aws_iam_access_key.rubrik-user.id
+    "aws_iam_secret_key" = data.template_file.iam_secret_key.rendered
+  }
+}
+
+output "aws_iam_policy" {
+  description = "The name ofthe AWS Policy created for the IAM User."
+  value       = aws_iam_policy.cloud-out-permissions.name
+}
+
+output "aws_bucket" {
+  description = "The AWS S3 bucket that was created."
+  value       = aws_s3_bucket.archive_target.bucket
+}
+
+output "aws_kms_key" {
+  description = "The KMS Key ID of the KMS key that was created."
+  value       = aws_kms_key.rubrik-cloudout.key_id
+}
+output "aws_region" {
+  description = "The AWS region where the resoruces were created."
+  value       = var.region
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,5 +27,5 @@ output "aws_kms_key" {
 }
 output "aws_region" {
   description = "The AWS region where the resoruces were created."
-  value       = var.region
+  value       = var.aws_region
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ data "template_file" "iam_secret_key" {
 output "aws_iam_user_info" {
   description = "The information about the AWS IAM User created."
   value       = {
-    "name"               = aws_iam_user.rubrik.name
+    "aws_iam_user_name" = aws_iam_user.rubrik.name
     "aws_iam_access_key" = aws_iam_access_key.rubrik-user.id
     "aws_iam_secret_key" = data.template_file.iam_secret_key.rendered
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,9 @@
-data "template_file" "iam_secret_key" {
-  template = aws_iam_access_key.rubrik-user.secret
+output "aws_iam_user_name" {
+  description = "The name of the AWS IAM User created."
+  value       = "${aws_iam_user.rubrik.name}"
 }
 
-output "aws_iam_user_info" {
-  description = "The information about the AWS IAM User created."
-  value       = {
-    "name"               = aws_iam_user.rubrik.name
-    "aws_iam_access_key" = aws_iam_access_key.rubrik-user.id
-    "aws_iam_secret_key" = data.template_file.iam_secret_key.rendered
-  }
-}
-
-output "aws_iam_policy" {
-  description = "The name ofthe AWS Policy created for the IAM User."
-  value       = aws_iam_policy.cloud-out-permissions.name
-}
-
-output "aws_bucket" {
-  description = "The AWS S3 bucket that was created."
-  value       = aws_s3_bucket.archive_target.bucket
-}
-
-output "aws_kms_key" {
-  description = "The KMS Key ID of the KMS key that was created."
-  value       = aws_kms_key.rubrik-cloudout.key_id
-}
-output "aws_region" {
-  description = "The AWS region where the resoruces were created."
-  value       = var.region
+output "rubrik_archive_name" {
+  description = "The name of the archival location created on the Rubrik cluster."
+  value       = "${rubrik_aws_s3_cloudout.archive-target.archive_name}"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,6 +1,11 @@
 #############################
 # Provider Configuration    #
 #############################
-provider "aws" {
-    region     = var.aws_region
+terraform {
+  required_version = ">= 0.12.20"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+variable "region" {
+  description = "The region to create resoruces for Rubrik CloudOut."
+}
+
 variable "bucket_name" {
   description = "The name of the S3 bucket to use as an archive target."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "region" {
-  description = "The region to create resoruces for Rubrik CloudOut."
-}
-
 variable "bucket_name" {
   description = "The name of the S3 bucket to use as an archive target."
 }


### PR DESCRIPTION
# Description

* Added support for Terraform 0.15
* Added missing ACL needed for newer versions of CDM. 
* Added region selection to TF script.
* Deprecated support for Rubrik Provider due to older provider not being supported beyond Terraform v0.11
* Added outputs needed to configure archival location in Rubrik.

## Related Issue

Fixes #10
Fixes #9 

## Motivation and Context

Keeping up with Terraform versions. 

## How Has This Been Tested?

Created and destroyed CloudOut pre-reqs using the new format in AWS with this Terraform script.

## Screenshots (if appropriate):

None 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
